### PR TITLE
feat: instantiate sentiment analyzer and add tests

### DIFF
--- a/src/modules/requirement-parser.ts
+++ b/src/modules/requirement-parser.ts
@@ -280,9 +280,8 @@ export class RequirementParser {
     confidence: number;
   }> {
     // Basic sentiment analysis
-    const sentiment = natural.SentimentAnalyzer.getSentiment(
-      this.tokenizer.tokenize(text) || []
-    );
+    const analyzer = new natural.SentimentAnalyzer('English', natural.PorterStemmer, 'afinn');
+    const sentiment = analyzer.getSentiment(this.tokenizer.tokenize(text));
 
     // Extract entities (simplified)
     const entities = this.extractEntities(text);

--- a/tests/requirement-parser.test.ts
+++ b/tests/requirement-parser.test.ts
@@ -1,0 +1,19 @@
+import { RequirementParser } from '../src/modules/requirement-parser';
+
+describe('RequirementParser analyze', () => {
+  let parser: RequirementParser;
+
+  beforeEach(() => {
+    parser = new RequirementParser();
+  });
+
+  it('returns positive sentiment for positive input', async () => {
+    const result = await parser.analyze('I love this application');
+    expect(result.sentiment).toBeGreaterThan(0);
+  });
+
+  it('returns negative sentiment for negative input', async () => {
+    const result = await parser.analyze('I hate this application');
+    expect(result.sentiment).toBeLessThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- replace static SentimentAnalyzer call with a properly instantiated analyzer
- add tests verifying positive and negative sentiment

## Testing
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config file)*
- `pnpm typecheck` *(fails: multiple TS errors in agents/*.ts)*
- `pnpm test` *(fails: jest permission denied)*

------
https://chatgpt.com/codex/tasks/task_b_68b8a4664d68832cb22550cf8627e1f1