### PR TITLE
feat: add tech stack union type and comprehensive detection tests

### DIFF
--- a/src/modules/requirement-parser.ts
+++ b/src/modules/requirement-parser.ts
@@ -7,10 +7,12 @@ interface ParsedFeature {
   category: string;
 }
 
+type TechValue = AppRequirements['techStack'][keyof AppRequirements['techStack']];
+
 export class RequirementParser {
   private tokenizer: natural.WordTokenizer;
   private stemmer: natural.PorterStemmer;
-  private techStackKeywords: Map<string, { type: keyof AppRequirements['techStack'], value: string }>;
+  private techStackKeywords: Map<string, { type: keyof AppRequirements['techStack']; value: TechValue }>;
   private featurePatterns: Map<RegExp, ParsedFeature>;
 
   constructor() {
@@ -155,7 +157,7 @@ export class RequirementParser {
     
     for (const [keyword, config] of this.techStackKeywords) {
       if (description.includes(keyword)) {
-        techStack[config.type] = config.value as any;
+        techStack[config.type] = config.value as TechValue;
       }
     }
 

--- a/tests/tech-stack-detection.test.ts
+++ b/tests/tech-stack-detection.test.ts
@@ -1,0 +1,48 @@
+import { RequirementParser } from '../src/modules/requirement-parser';
+import { AppRequirements } from '../src/types';
+
+describe('RequirementParser tech stack detection', () => {
+  const parser = new RequirementParser();
+
+  const cases: Array<{ keyword: string; type: keyof AppRequirements['techStack']; value: AppRequirements['techStack'][keyof AppRequirements['techStack']] }> = [
+    // Frontend keywords
+    { keyword: 'react', type: 'frontend', value: 'react' },
+    { keyword: 'vue', type: 'frontend', value: 'vue' },
+    { keyword: 'angular', type: 'frontend', value: 'angular' },
+    { keyword: 'svelte', type: 'frontend', value: 'svelte' },
+    { keyword: 'next.js', type: 'frontend', value: 'react' },
+    { keyword: 'nuxt', type: 'frontend', value: 'vue' },
+
+    // Backend keywords
+    { keyword: 'node', type: 'backend', value: 'nodejs' },
+    { keyword: 'nodejs', type: 'backend', value: 'nodejs' },
+    { keyword: 'express', type: 'backend', value: 'nodejs' },
+    { keyword: 'python', type: 'backend', value: 'python' },
+    { keyword: 'django', type: 'backend', value: 'python' },
+    { keyword: 'flask', type: 'backend', value: 'python' },
+    { keyword: 'golang', type: 'backend', value: 'golang' },
+    { keyword: 'go', type: 'backend', value: 'golang' },
+    { keyword: 'java', type: 'backend', value: 'java' },
+    { keyword: 'spring', type: 'backend', value: 'java' },
+
+    // Database keywords
+    { keyword: 'postgres', type: 'database', value: 'postgresql' },
+    { keyword: 'postgresql', type: 'database', value: 'postgresql' },
+    { keyword: 'mongo', type: 'database', value: 'mongodb' },
+    { keyword: 'mongodb', type: 'database', value: 'mongodb' },
+    { keyword: 'sqlite', type: 'database', value: 'sqlite' },
+    { keyword: 'mysql', type: 'database', value: 'mysql' },
+
+    // Deployment keywords
+    { keyword: 'docker', type: 'deployment', value: 'docker' },
+    { keyword: 'kubernetes', type: 'deployment', value: 'kubernetes' },
+    { keyword: 'k8s', type: 'deployment', value: 'kubernetes' },
+    { keyword: 'vercel', type: 'deployment', value: 'vercel' },
+    { keyword: 'aws', type: 'deployment', value: 'aws' },
+  ];
+
+  test.each(cases)("detects '%s' tech stack", async ({ keyword, type, value }) => {
+    const result = await parser.parse(`use ${keyword}`);
+    expect(result.techStack[type]).toBe(value);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce `TechValue` union to keep tech stack values type-safe
- update requirement parser to use `TechValue` instead of `any`
- add tests covering detection of all tech stack keywords

## Testing
- `pnpm lint` *(fails: ESLint couldn't find config "@typescript-eslint/recommended")*
- `pnpm typecheck` *(fails: agents files contain TypeScript errors)*
- `pnpm test` *(fails: Jest failed to parse TypeScript tests)*

------
https://chatgpt.com/codex/tasks/task_b_68b8a4671580832c8da6908901f1d5a8